### PR TITLE
feat: add recordcounts command

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -1,12 +1,12 @@
 [
-    {
-        "command": "force:limits:api:display",
-        "plugin": "@salesforce/plugin-limits",
-        "flags": [
-            "apiversion",
-            "json",
-            "loglevel",
-            "targetusername"
-        ]
-    }
+  {
+    "command": "force:limits:api:display",
+    "plugin": "@salesforce/plugin-limits",
+    "flags": ["apiversion", "json", "loglevel", "targetusername"]
+  },
+  {
+    "command": "force:limits:recordcounts:display",
+    "plugin": "@salesforce/plugin-limits",
+    "flags": ["apiversion", "json", "loglevel", "targetusername", "objectnames"]
+  }
 ]

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -7,6 +7,6 @@
   {
     "command": "force:limits:recordcounts:display",
     "plugin": "@salesforce/plugin-limits",
-    "flags": ["apiversion", "json", "loglevel", "targetusername", "sobjecttypes"]
+    "flags": ["apiversion", "json", "loglevel", "targetusername", "sobjecttype"]
   }
 ]

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -7,6 +7,6 @@
   {
     "command": "force:limits:recordcounts:display",
     "plugin": "@salesforce/plugin-limits",
-    "flags": ["apiversion", "json", "loglevel", "targetusername", "objectnames"]
+    "flags": ["apiversion", "json", "loglevel", "targetusername", "sobjecttypes"]
   }
 ]

--- a/messages/recordcounts.json
+++ b/messages/recordcounts.json
@@ -1,0 +1,8 @@
+{
+  "commandDescription": "print record counts for the given objects",
+  "examples": [
+    "sfdx force:limits:recordcounts:display -o Account,Contact,Lead,Opportunity",
+    "sfdx force:limits:recordcounts:display -o Account,Contact -u me@my.org"
+  ],
+  "objectnamesFlagDescription": "comma-separated list of object names for which to print record counts"
+}

--- a/messages/recordcounts.json
+++ b/messages/recordcounts.json
@@ -1,8 +1,8 @@
 {
   "commandDescription": "display record counts for the specified standard and custom objects",
   "examples": [
-    "sfdx force:limits:recordcounts:display -o Account,Contact,Lead,Opportunity",
-    "sfdx force:limits:recordcounts:display -o Account,Contact -u me@my.org"
+    "sfdx force:limits:recordcounts:display -s Account,Contact,Lead,Opportunity",
+    "sfdx force:limits:recordcounts:display -s Account,Contact -u me@my.org"
   ],
-  "objectnamesFlagDescription": "comma-separated list of API names of standard or custom objects for which to display record counts"
+  "sobjecttypesFlagDescription": "comma-separated list of API names of standard or custom objects for which to display record counts"
 }

--- a/messages/recordcounts.json
+++ b/messages/recordcounts.json
@@ -4,5 +4,5 @@
     "sfdx force:limits:recordcounts:display -s Account,Contact,Lead,Opportunity",
     "sfdx force:limits:recordcounts:display -s Account,Contact -u me@my.org"
   ],
-  "sobjecttypesFlagDescription": "comma-separated list of API names of standard or custom objects for which to display record counts"
+  "sobjecttypeFlagDescription": "comma-separated list of API names of standard or custom objects for which to display record counts"
 }

--- a/messages/recordcounts.json
+++ b/messages/recordcounts.json
@@ -1,5 +1,5 @@
 {
-  "commandDescription": "display record counts for the specified standard and custom objects",
+  "commandDescription": "display record counts for the specified standard and custom objects\nUse this command to get an approximate count of the records in standard or custom objects in your org. These record counts are the same as the counts listed in the Storage Usage page in Setup. The record counts are approximate because they're calculated asynchronously and your org’s storage usage isn’t updated immediately.",
   "examples": [
     "sfdx force:limits:recordcounts:display -s Account,Contact,Lead,Opportunity",
     "sfdx force:limits:recordcounts:display -s Account,Contact -u me@my.org"

--- a/messages/recordcounts.json
+++ b/messages/recordcounts.json
@@ -1,8 +1,8 @@
 {
-  "commandDescription": "print record counts for the given objects",
+  "commandDescription": "display record counts for the specified standard and custom objects",
   "examples": [
     "sfdx force:limits:recordcounts:display -o Account,Contact,Lead,Opportunity",
     "sfdx force:limits:recordcounts:display -o Account,Contact -u me@my.org"
   ],
-  "objectnamesFlagDescription": "comma-separated list of object names for which to print record counts"
+  "objectnamesFlagDescription": "comma-separated list of API names of standard or custom objects for which to display record counts"
 }

--- a/src/commands/force/limits/recordcounts/display.ts
+++ b/src/commands/force/limits/recordcounts/display.ts
@@ -39,18 +39,18 @@ export class LimitsRecordCountsDisplayCommand extends SfdxCommand {
   };
 
   protected static readonly flagsConfig: FlagsConfig = {
-    objectnames: flags.array({
-      char: 'o',
+    sobjecttypes: flags.array({
+      char: 's',
       required: true,
-      description: messages.getMessage('objectnamesFlagDescription'),
+      description: messages.getMessage('sobjecttypesFlagDescription'),
     }),
   };
 
   public async run(): Promise<RecordCount[]> {
     try {
-      const objectnamesString = (this.flags.objectnames as string[]).join();
+      const sobjecttypesString = (this.flags.sobjecttypes as string[]).join();
       const conn = this.org.getConnection();
-      const geturl = `${conn.instanceUrl}/services/data/v${conn.version}/limits/recordCount?sObjects=${objectnamesString}`;
+      const geturl = `${conn.instanceUrl}/services/data/v${conn.version}/limits/recordCount?sObjects=${sobjecttypesString}`;
       const result = ((await conn.request(geturl)) as unknown) as Result;
 
       return result.sObjects;

--- a/src/commands/force/limits/recordcounts/display.ts
+++ b/src/commands/force/limits/recordcounts/display.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import * as os from 'os';
+import { flags, FlagsConfig, SfdxCommand, SfdxResult } from '@salesforce/command';
+import { Messages, SfdxError } from '@salesforce/core';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/plugin-limits', 'recordcounts');
+
+interface RecordCount {
+  name: string;
+  count: number;
+}
+
+interface Result {
+  sObjects: RecordCount[];
+}
+
+export class LimitsRecordCountsDisplayCommand extends SfdxCommand {
+  public static readonly description = messages.getMessage('commandDescription');
+  public static readonly examples = messages.getMessage('examples').split(os.EOL);
+  public static readonly requiresUsername = true;
+  public static readonly result: SfdxResult = {
+    tableColumnData: {
+      columns: [
+        { key: 'name', label: 'sObject' },
+        { key: 'count', label: 'Record Count' },
+      ],
+    },
+    display() {
+      if (Array.isArray(this.data) && this.data.length) {
+        this.ux.table(this.data, this.tableColumnData);
+      }
+    },
+  };
+
+  protected static readonly flagsConfig: FlagsConfig = {
+    objectnames: flags.array({
+      char: 'o',
+      required: true,
+      description: messages.getMessage('objectnamesFlagDescription'),
+    }),
+  };
+
+  public async run(): Promise<RecordCount[]> {
+    try {
+      const objectnamesString = (this.flags.objectnames as string[]).join();
+      const conn = this.org.getConnection();
+      const geturl = `${conn.instanceUrl}/services/data/v${conn.version}/limits/recordCount?sObjects=${objectnamesString}`;
+      const result = ((await conn.request(geturl)) as unknown) as Result;
+
+      return result.sObjects;
+    } catch (err) {
+      throw SfdxError.wrap(err);
+    }
+  }
+}

--- a/src/commands/force/limits/recordcounts/display.ts
+++ b/src/commands/force/limits/recordcounts/display.ts
@@ -39,18 +39,18 @@ export class LimitsRecordCountsDisplayCommand extends SfdxCommand {
   };
 
   protected static readonly flagsConfig: FlagsConfig = {
-    sobjecttypes: flags.array({
+    sobjecttype: flags.array({
       char: 's',
       required: true,
-      description: messages.getMessage('sobjecttypesFlagDescription'),
+      description: messages.getMessage('sobjecttypeFlagDescription'),
     }),
   };
 
   public async run(): Promise<RecordCount[]> {
     try {
-      const sobjecttypesString = (this.flags.sobjecttypes as string[]).join();
+      const sobjecttypeString = (this.flags.sobjecttype as string[]).join();
       const conn = this.org.getConnection();
-      const geturl = `${conn.instanceUrl}/services/data/v${conn.version}/limits/recordCount?sObjects=${sobjecttypesString}`;
+      const geturl = `${conn.instanceUrl}/services/data/v${conn.version}/limits/recordCount?sObjects=${sobjecttypeString}`;
       const result = ((await conn.request(geturl)) as unknown) as Result;
 
       return result.sObjects;

--- a/test/commands/recordcounts.test.ts
+++ b/test/commands/recordcounts.test.ts
@@ -22,7 +22,7 @@ describe('force:limits:recordcounts:display', () => {
     test
       .do(() => prepareStubs())
       .stdout()
-      .command(['force:limits:recordcounts:display', '--objectnames', 'Account,Contact,Lead', '--json'])
+      .command(['force:limits:recordcounts:display', '--sobjecttype', 'Account,Contact,Lead', '--json'])
       .it('displays the expected results correctly', (ctx) => {
         const expected = [
           {

--- a/test/commands/recordcounts.test.ts
+++ b/test/commands/recordcounts.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { Connection, Org } from '@salesforce/core';
+import { $$, test, expect } from '@salesforce/command/lib/test';
+
+describe('force:limits:recordcounts:display', () => {
+  async function prepareStubs() {
+    $$.SANDBOX.stub(Org.prototype, 'getConnection').callsFake(() => Connection.prototype);
+    $$.SANDBOX.stub(Connection.prototype, 'request').resolves({
+      sObjects: [
+        { count: 34, name: 'Account' },
+        { count: 116, name: 'Contact' },
+      ],
+    });
+  }
+
+  it('queries and aggregates data correctly', () => {
+    test
+      .do(() => prepareStubs())
+      .stdout()
+      .command(['force:limits:recordcounts:display', '--objectnames', 'Account,Contact,Lead', '--json'])
+      .it('displays the expected results correctly', (ctx) => {
+        const expected = [
+          {
+            name: 'Account',
+            count: 34,
+          },
+          {
+            name: 'Contact',
+            count: 116,
+          },
+        ];
+
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+        const result = JSON.parse(ctx.stdout).result;
+        expect(result).to.deep.equal(expected);
+      });
+  });
+});


### PR DESCRIPTION
### What does this PR do?
Adds a new command force:limits:recordcounts:display that queries the /services/data/<version>/limits/recordCounts REST API and prints record counts for sObjects given with parameter --objectnames

Example:
```bash
> sfdx force:limits:recordcounts:display --objectnames Account,Contact
sObject Record Count
-------- -------------
Account 34
Contact 116
```

### What issues does this PR fix or reference?
Closes forcedotcom/cli#978